### PR TITLE
Support for using printv in a dumped core image

### DIFF
--- a/printv.lisp
+++ b/printv.lisp
@@ -7,7 +7,7 @@
 ;; Configurables - Adjust to Individual Taste
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defvar *default-printv-output*     *trace-output*)
+(defvar *default-printv-output*     (make-synonym-stream '*trace-output*))
 (defvar *printv-output*             *default-printv-output*)
 (defvar *printv-lock*               (make-recursive-lock))
 


### PR DESCRIPTION
This adds support for using printv as part of a core image dumped with SBCL. The problem was that the default output stream is bound to a stream that's valid in the original process, but is closed as part of dumping the image, so no longer prints output in an SBCL using this dumped core image. This fixes that.